### PR TITLE
Command karma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9.4
+      - name: Set up Python 3.9.5
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9.4
+          python-version: 3.9.5
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -93,14 +93,12 @@ class KarmaBot(App):
             msg = msg[1:]
         return msg
 
-
     @staticmethod
     def _check_for_self_bump(msg: dict) -> bool:
         """Returns true if the passed message text contains a self-bump, i.e. the sending
         username is also present in the text as the karma target.
         """
         return msg["user"] in msg["text"]
-
 
     def get_username_from_uid(self, uid: str) -> str:
 
@@ -116,7 +114,6 @@ class KarmaBot(App):
         except SlackApiError as e:
             self.logger.error("Error fetching username for {}: {}".format(uid, e))
             return None
-
 
     def increment_karma(self, msg: dict) -> str:
         """Increment karma for a passed item, and pass a corresponding message to the

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -101,7 +101,6 @@ class KarmaBot(App):
         return msg["user"] in msg["text"]
 
     def get_username_from_uid(self, uid: str) -> str:
-
         """Fetch the username corresponding to the passed UID string."""
         if not uid:
             return None
@@ -142,16 +141,12 @@ class KarmaBot(App):
         self.logger.debug("Got increment for %s", item)
         return f"{snark} {item} now has {total} points{tail}."
 
-    def decrement_karma(self, msg: dict, user: str = None) -> str:
+    def decrement_karma(self, msg: dict) -> str:
         """Decrement karma for a passed item, and pass a corresponding message to the
         channel inside which the karma was bumped to be sent.
 
         Arguments:
         msg -- text containing a karma event
-        user -- UID specifying which user triggered the karma event.  If not None, then
-                the username string corresponding to this UID is fetched and printed.
-                This is to allow karma events triggered via the use of slash-commands to
-                show which user is responsible for the karma event.
 
         Returns:
         A message to be sent back to the channel in which the karma event occurred.

--- a/karma_chameleon/main.py
+++ b/karma_chameleon/main.py
@@ -55,12 +55,14 @@ app = KarmaBot(
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
 )
 
+
 @app.middleware
 def log_message(
-    body: dict, next: Callable # pylint: disable=redefined-builtin
-) -> Union[Callable, BoltResponse]: # pylint: disable=unsubscriptable-object
+    body: dict, next: Callable  # pylint: disable=redefined-builtin
+) -> Union[Callable, BoltResponse]:  # pylint: disable=unsubscriptable-object
     logger.debug("Received message: %s" % str(body))
     return next()
+
 
 @app.middleware
 def handle_no_karma_op(
@@ -72,12 +74,14 @@ def handle_no_karma_op(
     Unfortunately the Slack Bolt API requires that the next middleware method be referred
     to as "next", which is a built-in.  You can't win them all I suppose...
 
-    Arguments: body -- a dict containing the entire Slack Bolt API event next_middleware
-    -- callable reference to the next middleware listener.
+    Arguments:
+    body -- a dict containing the entire Slack Bolt API event
+    next -- callable reference to the next middleware listener.
 
-    Returns: If the incoming event contains a karma operation, then the next middleware
-    listener is returned and invoked by the caller of this middleware.  If there is no
-    karma operation contained in the event, and the event is not a command, then a
+    Returns:
+    If the incoming event contains a karma operation, then the next middleware listener
+    is returned and invoked by the caller of this middleware.  If there is no karma
+    operation contained in the event, and the event is not a command, then a
     BoltResponse(200) is returned as we have nothing further to do.
     """
     if body.get("command"):
@@ -92,14 +96,50 @@ def handle_no_karma_op(
     return BoltResponse(status=200, body="Ignoring event with no karma operation")
 
 
+@app.command("/k")
+def handle_karma_command(ack: Ack, say: Say, command: dict) -> None:
+    """Trigger a karma event, either increment or decrement.  The format of the command is
+    as follows:
+
+        /k SUBJECT (++|--) trailing_garbage
+
+    The type of the karma event is determined by the use of "++" or "--" as indicated in
+    the above syntax.  Trailing garbage is any explanation or other flavor text the user
+    may provide in order to justify their awarding of karma, but it does nothing for this
+    bot so it is ignored.  The SUBJECT of a karma event may be either a username via the
+    "@" syntax of Slack, or an object.  Objects may be formatted as hashtags, but it
+    doesn't matter as the symbol is stripped anyway.
+
+    Arguments:
+    ack -- acknowledgement method, called to acknowledge the command was received
+    say -- method for printing back to the same channel from which the command was run
+    command -- dictionary specifying the command, including any text which was pased
+    """
+    ack()
+    event_type = command["text"].split()[1]
+    uid = command["user_id"]
+
+    msg = {
+        "text": command["text"],
+        "user": uid,
+    }
+
+    if event_type == "++":
+        say(app.increment_karma(msg))
+    elif event_type == "--":
+        say(app.decrement_karma(msg))
+    else:
+        say("Hmmm... this doesn't look right.  Syntx is '/k SUBJECT (++|--) [FLAVOR]")
+
+
 @app.message(app.inc_regex)
 def increment(message: dict, say: Say) -> None:
     """Passes the message along for to the KarmaChameleon bot, then posts a response based
     on the return value of the bot's increment method.
 
-    Arguments: message -- dictionary representation of the message which contains a karma
-    operation say -- method for printing back to the same channel from which the command
-    was run
+    Arguments:
+    message -- dictionary representation of the message which contains a karma operation
+    say -- method for printing back to the same channel from which the command was run
     """
     rsp = app.increment_karma(message)
     say(rsp)
@@ -110,9 +150,9 @@ def decrement(message: dict, say: Say) -> None:
     """Passes the message along for to the KarmaChameleon bot, then posts a response based
     on the return value of the bot's decrement method.
 
-    Arguments: message -- dictionary representation of the message which contains a karma
-    operation say -- method for printing back to the same channel from which the command
-    was run
+    Arguments:
+    message -- dictionary representation of the message which contains a karma operation
+    say -- method for printing back to the same channel from which the command was run
     """
     rsp = app.decrement_karma(message)
     say(rsp)
@@ -122,9 +162,9 @@ def decrement(message: dict, say: Say) -> None:
 def show_leaderboard(ack: Ack, say: Say) -> None:
     """Invoke leaderboard display from the karmaChameleon bot.
 
-    Arguments: ack -- acknowledgement method, called to acknowledge the command was
-    received say -- method for printing back to the same channel from which the command
-    was run
+    Arguments:
+    ack -- acknowledgement method, called to acknowledge the command was received
+    say -- method for printing back to the same channel from which the command was run
     """
     # Must acknowledge the command was run.
     ack()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -130,13 +130,13 @@ class TestBot(TestCase):
         assert bot.karma == {}
         for count in range(1, 2):
             msg = bot.increment_karma({"user": "foobar", "text": "@GraceHopper++"})
-            assert f"GraceHopper now has {count} points." in msg
+            assert f"GraceHopper now has {count} points" in msg
             assert "GraceHopper" in bot.karma
 
         assert "AdaLovelace" not in bot.karma
         for count in range(1, 2):
             msg = bot.decrement_karma({"user": "foobar", "text": "@AdaLovelace--"})
-            assert f"AdaLovelace now has -{count} points." in msg
+            assert f"AdaLovelace now has -{count} points" in msg
             assert "AdaLovelace" in bot.karma
 
         msg = bot.increment_karma({"user": "GraceHopper", "text": "@GraceHopper++"})


### PR DESCRIPTION
The current implementation of KC requires that it be privy to all messages sent in all rooms in which it is a member.   The changes in this request take a different approach, and one that is more mindful of user privacy concerns.  Instead of snooping on all messages, KC can now dole out or take away user or thing karma based on a slash command.  The syntax of said command is as follows:

/k SUBJECT (++|--) [flavor text]

Once run, karma is processed as normal, with the addition that the user who invoked the operation is now mentioned in the bot response.

This change also cleans up method docstrings, the format of which got messed up somehow in a previous change.