### PR TITLE
Replace Pylint with Ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check
 check:
 	black --check --color --diff .
-	pylint karma_chameleon tests
+	ruff karma_chameleon tests
 	flake8
 
 .PHONY: format

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -111,8 +111,7 @@ class KarmaBot(App):
         The URL regex is shamelessly copied from https://urlregex.com/.
         """
         url_re = re.compile(
-            r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|"
-            r"(?:%[0-9a-fA-F][0-9a-fA-F]))+"
+            r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
         )
 
         for word in msg["text"].split():

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -110,7 +110,7 @@ class KarmaBot(App):
 
         The URL regex is shamelessly copied from https://urlregex.com/.
         """
-        url_re = re.compile(r"https?://(?:[\w]|[$-_@.&+]|[!*\(\),]|(%[0-9a-fA-F][0-9a-fA-F]))+")
+        url_re = re.compile(r"https?://(?:[\w]|[$-_+]|[!*\(\),]|(%[0-9a-fA-F][0-9a-fA-F]))+")
 
         for word in msg["text"].split():
             # As of the writing of this code, "++" is not able to be included, unencoded,

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -110,7 +110,7 @@ class KarmaBot(App):
 
         The URL regex is shamelessly copied from https://urlregex.com/.
         """
-        url_re = re.compile(r"https?://(?:[\w]|[$-_+]|[!*\(\),]|(%[0-9a-fA-F][0-9a-fA-F]))+")
+        url_re = re.compile(r"https?://(?:[\w]|[$-_]|[!*\(\),]|(%[0-9a-fA-F][0-9a-fA-F]))+")
 
         for word in msg["text"].split():
             # As of the writing of this code, "++" is not able to be included, unencoded,

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -110,7 +110,7 @@ class KarmaBot(App):
 
         The URL regex is shamelessly copied from https://urlregex.com/.
         """
-        url_re = re.compile(r"https?://(?:[\w]|[$\-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
+        url_re = re.compile(r"https?://(?:[\w]|[$-_@.&+]|[!*\(\),]|(%[0-9a-fA-F][0-9a-fA-F]))+")
 
         for word in msg["text"].split():
             # As of the writing of this code, "++" is not able to be included, unencoded,

--- a/karma_chameleon/bot.py
+++ b/karma_chameleon/bot.py
@@ -1,4 +1,4 @@
-# Karma Chameleon Copyright (C) 2021 Dustin Schoenbrun, Will Rideout, Ben Decato
+# Karma Chameleon Copyright (C) 2023 Dustin Schoenbrun, Will Rideout, Ben Decato
 #
 # This program is free software: you can redistribute it and/or modify it under the terms
 # of the GNU General Public License as published by the Free Software Foundation, either
@@ -110,9 +110,7 @@ class KarmaBot(App):
 
         The URL regex is shamelessly copied from https://urlregex.com/.
         """
-        url_re = re.compile(
-            r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
-        )
+        url_re = re.compile(r"https?://(?:[\w]|[$\-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 
         for word in msg["text"].split():
             # As of the writing of this code, "++" is not able to be included, unencoded,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,6 @@ branch = true
 [tool.coverage.report]
 precision = 2
 
-[tool.pylint.MASTER]
-jobs = 0
-suggestion-mode = "yes"
-
-[tool.pylint.FORMAT]
-max-line-length = 100
-expected-line-ending-format = "LF"
-
-[tool.pylint.BASIC]
-argument-naming-style = "snake_case"
-
+[tool.ruff]
+line-length = 100
+target-version = "py311"

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 black ~= 22.12.0
 Flask ~= 2.2.2
 flake8 ~= 6.0.0
-pylint ~= 2.16.1
 pytest ~= 7.2.1
 pytest-cov ~= 4.0.0
+ruff ~= 0.0.241
 slack_bolt ~= 1.16.1
 tabulate ~= 0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --resolver=backtracking
 #
-astroid==2.14.1
-    # via pylint
 attrs==22.2.0
     # via pytest
 black==22.12.0
@@ -16,30 +14,22 @@ click==8.1.3
     #   flask
 coverage[toml]==7.0.4
     # via pytest-cov
-dill==0.3.6
-    # via pylint
 flake8==6.0.0
     # via -r requirements.in
 flask==2.2.2
     # via -r requirements.in
 iniconfig==2.0.0
     # via pytest
-isort==5.11.4
-    # via pylint
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-lazy-object-proxy==1.9.0
-    # via astroid
 markupsafe==2.1.1
     # via
     #   jinja2
     #   werkzeug
 mccabe==0.7.0
-    # via
-    #   flake8
-    #   pylint
+    # via flake8
 mypy-extensions==0.4.3
     # via black
 packaging==23.0
@@ -47,22 +37,20 @@ packaging==23.0
 pathspec==0.10.3
     # via black
 platformdirs==2.6.2
-    # via
-    #   black
-    #   pylint
+    # via black
 pluggy==1.0.0
     # via pytest
 pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-pylint==2.16.1
-    # via -r requirements.in
 pytest==7.2.1
     # via
     #   -r requirements.in
     #   pytest-cov
 pytest-cov==4.0.0
+    # via -r requirements.in
+ruff==0.0.241
     # via -r requirements.in
 slack-bolt==1.16.1
     # via -r requirements.in
@@ -70,9 +58,5 @@ slack-sdk==3.19.5
     # via slack-bolt
 tabulate==0.9.0
     # via -r requirements.in
-tomlkit==0.11.6
-    # via pylint
 werkzeug==2.2.2
     # via flask
-wrapt==1.14.1
-    # via astroid


### PR DESCRIPTION
Ruff is a new linter for Python that is written in Rust that is vastly faster than Pylint (milliseconds vs. seconds). This patch updates our linter to use Ruff instead of Pylint and updates the Makefile to use it as well.